### PR TITLE
Add HF integration

### DIFF
--- a/trains/singleTask/model/DLF.py
+++ b/trains/singleTask/model/DLF.py
@@ -7,7 +7,14 @@ import torch.nn.functional as F
 from ...subNets import BertTextEncoder
 from ...subNets.transformers_encoder.transformer import TransformerEncoder   
 
-class DLF(nn.Module):
+from huggingface_hub import PyTorchModelHubMixin
+
+
+class DLF(nn.Module, PyTorchModelHubMixin,
+          repo_url="https://github.com/pwang322/DLF",
+          paper_url="https://huggingface.co/papers/2412.12225",
+          tags=["sentiment-analysis"],
+          license="mit"):
     def __init__(self, args):
         super(DLF, self).__init__()
         if args.use_bert:


### PR DESCRIPTION
This PR adds an integration with the 🤗 hub so that you can automatically load the model using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Could you try it out like so?

```python
from trains.singleTask.model.DLF import DLF

model = DLF(...)

# equip with weights
model.load_state_dict(...)

# push to the hub
model.push_to_hub("your-hf-username-or-org/dlf")

# now anyone can use it like so:
model = DLF.from_pretrained("your-hf-username-or-org/dlf")
```

Fixes #4 